### PR TITLE
Using PerLogicalCallContextScopeManagerProvider instead of default per thread

### DIFF
--- a/src/LightInject.NServiceBus/LightInject.NServiceBus.cs
+++ b/src/LightInject.NServiceBus/LightInject.NServiceBus.cs
@@ -17,7 +17,10 @@ namespace LightInject.NServiceBus
 
         public LightInjectObjectBuilder()
         {
-            container = new ServiceContainer(new ContainerOptions { EnableVariance = false });
+            container = new ServiceContainer(new ContainerOptions {EnableVariance = false})
+            {
+                ScopeManagerProvider = new PerLogicalCallContextScopeManagerProvider()
+            };
             scope = container.BeginScope();
             isRootScope = true;
         }


### PR DESCRIPTION
The PerLogicalCallContextScopeManagerProvider is better suited for the async nature of core v6. We had failing builds with Rabbit by using the per thread provider